### PR TITLE
Fix read_ply duplicated symbols between libigl and geogram

### DIFF
--- a/include/igl/guess_extension.cpp
+++ b/include/igl/guess_extension.cpp
@@ -21,7 +21,7 @@ IGL_INLINE void igl::guess_extension(FILE * fp, std::string & guess)
   {
     int nelems;
     char ** elem_names;
-    PlyFile * in_ply = ply_read(ply_file,&nelems,&elem_names);
+    external::ply::PlyFile * in_ply = external::ply::ply_read(ply_file,&nelems,&elem_names);
     if(in_ply==NULL)
     {
       return false;

--- a/include/igl/guess_extension.cpp
+++ b/include/igl/guess_extension.cpp
@@ -1,4 +1,7 @@
 #include "guess_extension.h"
+
+#include <string.h>
+
 #include "is_stl.h"
 #include "ply.h"
 
@@ -21,7 +24,7 @@ IGL_INLINE void igl::guess_extension(FILE * fp, std::string & guess)
   {
     int nelems;
     char ** elem_names;
-    external::ply::PlyFile * in_ply = external::ply::ply_read(ply_file,&nelems,&elem_names);
+    igl::ply::PlyFile * in_ply = igl::ply::ply_read(ply_file,&nelems,&elem_names);
     if(in_ply==NULL)
     {
       return false;

--- a/include/igl/ply.h
+++ b/include/igl/ply.h
@@ -72,14 +72,15 @@ properly to target OSs with binary files.
 #ifndef __PLY_H__
 #define __PLY_H__
 
-namespace igl {
-  namespace external {
-    namespace ply {
+
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
+
+namespace igl {
+    namespace ply {
     
 #define PLY_ASCII         1      /* ascii PLY file */
 #define PLY_BINARY_BE     2      /* binary PLY file, big endian */
@@ -105,6 +106,8 @@ namespace igl {
 
 #define  PLY_SCALAR  0
 #define  PLY_LIST    1
+
+
 
 
 typedef struct PlyProperty {    /* description of a property */
@@ -245,7 +248,6 @@ inline int equal_strings(const char *, const char *);
 
 }
 }
-}
 #endif /* !__PLY_H__ */
 /*
 
@@ -325,7 +327,6 @@ properly to target OSs with binary files.
 
 
 namespace igl {
-  namespace external {
     namespace ply {
 
 
@@ -3161,7 +3162,6 @@ inline char *my_alloc(int size, int lnum, const char *fe)
   return (ptr);
 }
 
-}
 }
 }
 #endif

--- a/include/igl/ply.h
+++ b/include/igl/ply.h
@@ -72,9 +72,9 @@ properly to target OSs with binary files.
 #ifndef __PLY_H__
 #define __PLY_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+namespace igl {
+  namespace external {
+    namespace ply {
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -243,9 +243,9 @@ inline void ply_describe_other_properties(PlyFile *, PlyOtherProp *, int);
 inline int equal_strings(const char *, const char *);
 
 
-#ifdef __cplusplus
 }
-#endif
+}
+}
 #endif /* !__PLY_H__ */
 /*
 
@@ -322,6 +322,12 @@ properly to target OSs with binary files.
 #include <math.h>
 #include <string.h>
 //#include "ply.h"
+
+
+namespace igl {
+  namespace external {
+    namespace ply {
+
 
 // Use unnamed namespace to avoid duplicate symbols
 /*
@@ -3155,5 +3161,7 @@ inline char *my_alloc(int size, int lnum, const char *fe)
   return (ptr);
 }
 
-
+}
+}
+}
 #endif

--- a/include/igl/readPLY.cpp
+++ b/include/igl/readPLY.cpp
@@ -58,7 +58,7 @@ IGL_INLINE bool igl::readPLY(
      void *other_props;       /* other properties */
    } Face;
 
-  PlyProperty vert_props[] = { /* list of property information for a vertex */
+  external::ply::PlyProperty vert_props[] = { /* list of property information for a vertex */
     {"x", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,x), 0, 0, 0, 0},
     {"y", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,y), 0, 0, 0, 0},
     {"z", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,z), 0, 0, 0, 0},
@@ -69,14 +69,14 @@ IGL_INLINE bool igl::readPLY(
     {"t", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,t), 0, 0, 0, 0},
   };
 
-  PlyProperty face_props[] = { /* list of property information for a face */
+  external::ply::PlyProperty face_props[] = { /* list of property information for a face */
     {"vertex_indices", PLY_INT, PLY_INT, offsetof(Face,verts),
       1, PLY_UCHAR, PLY_UCHAR, offsetof(Face,nverts)},
   };
 
   int nelems;
   char ** elem_names;
-  PlyFile * in_ply = ply_read(ply_file,&nelems,&elem_names);
+  external::ply::PlyFile * in_ply = external::ply::ply_read(ply_file,&nelems,&elem_names);
   if(in_ply==NULL)
   {
     return false;
@@ -84,11 +84,11 @@ IGL_INLINE bool igl::readPLY(
 
   bool has_normals = false;
   bool has_texture_coords = false;
-  PlyProperty **plist;
+  external::ply::PlyProperty **plist;
   int nprops;
   int elem_count;
   plist = ply_get_element_description (in_ply,"vertex", &elem_count, &nprops);
-  int native_binary_type = get_native_binary_type2();
+  int native_binary_type = external::ply::get_native_binary_type2();
   if (plist != NULL)
   {
     /* set up for getting vertex elements */
@@ -97,18 +97,18 @@ IGL_INLINE bool igl::readPLY(
     ply_get_property (in_ply,"vertex",&vert_props[2]);
     for (int j = 0; j < nprops; j++)
     {
-      PlyProperty * prop = plist[j];
-      if (equal_strings ("nx", prop->name) 
-        || equal_strings ("ny", prop->name)
-        || equal_strings ("nz", prop->name))
+      external::ply::PlyProperty * prop = plist[j];
+      if (external::ply::equal_strings ("nx", prop->name) 
+        || external::ply::equal_strings ("ny", prop->name)
+        || external::ply::equal_strings ("nz", prop->name))
       {
         ply_get_property (in_ply,"vertex",&vert_props[3]);
         ply_get_property (in_ply,"vertex",&vert_props[4]);
         ply_get_property (in_ply,"vertex",&vert_props[5]);
         has_normals = true;
       }
-      if (equal_strings ("s", prop->name) ||
-        equal_strings ("t", prop->name))
+      if (external::ply::equal_strings ("s", prop->name) ||
+        external::ply::equal_strings ("t", prop->name))
       {
         ply_get_property(in_ply,"vertex",&vert_props[6]);
         ply_get_property(in_ply,"vertex",&vert_props[7]);

--- a/include/igl/readPLY.cpp
+++ b/include/igl/readPLY.cpp
@@ -58,7 +58,7 @@ IGL_INLINE bool igl::readPLY(
      void *other_props;       /* other properties */
    } Face;
 
-  external::ply::PlyProperty vert_props[] = { /* list of property information for a vertex */
+  igl::ply::PlyProperty vert_props[] = { /* list of property information for a vertex */
     {"x", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,x), 0, 0, 0, 0},
     {"y", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,y), 0, 0, 0, 0},
     {"z", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,z), 0, 0, 0, 0},
@@ -69,14 +69,14 @@ IGL_INLINE bool igl::readPLY(
     {"t", PLY_DOUBLE, PLY_DOUBLE, offsetof(Vertex,t), 0, 0, 0, 0},
   };
 
-  external::ply::PlyProperty face_props[] = { /* list of property information for a face */
+  igl::ply::PlyProperty face_props[] = { /* list of property information for a face */
     {"vertex_indices", PLY_INT, PLY_INT, offsetof(Face,verts),
       1, PLY_UCHAR, PLY_UCHAR, offsetof(Face,nverts)},
   };
 
   int nelems;
   char ** elem_names;
-  external::ply::PlyFile * in_ply = external::ply::ply_read(ply_file,&nelems,&elem_names);
+  igl::ply::PlyFile * in_ply = igl::ply::ply_read(ply_file,&nelems,&elem_names);
   if(in_ply==NULL)
   {
     return false;
@@ -84,11 +84,11 @@ IGL_INLINE bool igl::readPLY(
 
   bool has_normals = false;
   bool has_texture_coords = false;
-  external::ply::PlyProperty **plist;
+  igl::ply::PlyProperty **plist;
   int nprops;
   int elem_count;
   plist = ply_get_element_description (in_ply,"vertex", &elem_count, &nprops);
-  int native_binary_type = external::ply::get_native_binary_type2();
+  int native_binary_type = igl::ply::get_native_binary_type2();
   if (plist != NULL)
   {
     /* set up for getting vertex elements */
@@ -97,18 +97,18 @@ IGL_INLINE bool igl::readPLY(
     ply_get_property (in_ply,"vertex",&vert_props[2]);
     for (int j = 0; j < nprops; j++)
     {
-      external::ply::PlyProperty * prop = plist[j];
-      if (external::ply::equal_strings ("nx", prop->name) 
-        || external::ply::equal_strings ("ny", prop->name)
-        || external::ply::equal_strings ("nz", prop->name))
+      igl::ply::PlyProperty * prop = plist[j];
+      if (igl::ply::equal_strings ("nx", prop->name) 
+        || igl::ply::equal_strings ("ny", prop->name)
+        || igl::ply::equal_strings ("nz", prop->name))
       {
         ply_get_property (in_ply,"vertex",&vert_props[3]);
         ply_get_property (in_ply,"vertex",&vert_props[4]);
         ply_get_property (in_ply,"vertex",&vert_props[5]);
         has_normals = true;
       }
-      if (external::ply::equal_strings ("s", prop->name) ||
-        external::ply::equal_strings ("t", prop->name))
+      if (igl::ply::equal_strings ("s", prop->name) ||
+        igl::ply::equal_strings ("t", prop->name))
       {
         ply_get_property(in_ply,"vertex",&vert_props[6]);
         ply_get_property(in_ply,"vertex",&vert_props[7]);

--- a/include/igl/writePLY.cpp
+++ b/include/igl/writePLY.cpp
@@ -56,7 +56,7 @@ IGL_INLINE bool igl::writePLY(
     FScalar *verts;              /* vertex index list */
   } Face;
 
-  external::ply::PlyProperty vert_props[] =
+  igl::ply::PlyProperty vert_props[] =
   { /* list of property information for a vertex */
     {"x", ply_type<VScalar>(), ply_type<VScalar>(),offsetof(Vertex,x),0,0,0,0},
     {"y", ply_type<VScalar>(), ply_type<VScalar>(),offsetof(Vertex,y),0,0,0,0},
@@ -68,7 +68,7 @@ IGL_INLINE bool igl::writePLY(
     {"t", ply_type<UVScalar>(),ply_type<UVScalar>(),offsetof(Vertex,t),0,0,0,0},
   };
 
-  external::ply::PlyProperty face_props[] =
+  igl::ply::PlyProperty face_props[] =
   { /* list of property information for a face */
     {"vertex_indices", ply_type<FScalar>(), ply_type<FScalar>(), 
       offsetof(Face,verts), 1, PLY_UCHAR, PLY_UCHAR, offsetof(Face,nverts)},
@@ -110,14 +110,14 @@ IGL_INLINE bool igl::writePLY(
   {
     return false;
   }
-  external::ply::PlyFile * ply = external::ply::ply_write(fp, 2,elem_names,
+  igl::ply::PlyFile * ply = igl::ply::ply_write(fp, 2,elem_names,
       (ascii ? PLY_ASCII : PLY_BINARY_LE));
   if(ply==NULL)
   {
     return false;
   }
 
-  std::vector<external::ply::PlyProperty> plist;
+  std::vector<igl::ply::PlyProperty> plist;
   plist.push_back(vert_props[0]);
   plist.push_back(vert_props[1]);
   plist.push_back(vert_props[2]);
@@ -137,7 +137,7 @@ IGL_INLINE bool igl::writePLY(
 
   ply_describe_element(ply, "face", F.rows(),1,&face_props[0]);
   ply_header_complete(ply);
-  int native_binary_type = external::ply::get_native_binary_type2();
+  int native_binary_type = igl::ply::get_native_binary_type2();
   ply_put_element_setup(ply, "vertex");
   for(const auto v : vlist)
   {

--- a/include/igl/writePLY.cpp
+++ b/include/igl/writePLY.cpp
@@ -56,7 +56,7 @@ IGL_INLINE bool igl::writePLY(
     FScalar *verts;              /* vertex index list */
   } Face;
 
-  PlyProperty vert_props[] =
+  external::ply::PlyProperty vert_props[] =
   { /* list of property information for a vertex */
     {"x", ply_type<VScalar>(), ply_type<VScalar>(),offsetof(Vertex,x),0,0,0,0},
     {"y", ply_type<VScalar>(), ply_type<VScalar>(),offsetof(Vertex,y),0,0,0,0},
@@ -68,7 +68,7 @@ IGL_INLINE bool igl::writePLY(
     {"t", ply_type<UVScalar>(),ply_type<UVScalar>(),offsetof(Vertex,t),0,0,0,0},
   };
 
-  PlyProperty face_props[] =
+  external::ply::PlyProperty face_props[] =
   { /* list of property information for a face */
     {"vertex_indices", ply_type<FScalar>(), ply_type<FScalar>(), 
       offsetof(Face,verts), 1, PLY_UCHAR, PLY_UCHAR, offsetof(Face,nverts)},
@@ -110,14 +110,14 @@ IGL_INLINE bool igl::writePLY(
   {
     return false;
   }
-  PlyFile * ply = ply_write(fp, 2,elem_names,
+  external::ply::PlyFile * ply = external::ply::ply_write(fp, 2,elem_names,
       (ascii ? PLY_ASCII : PLY_BINARY_LE));
   if(ply==NULL)
   {
     return false;
   }
 
-  std::vector<PlyProperty> plist;
+  std::vector<external::ply::PlyProperty> plist;
   plist.push_back(vert_props[0]);
   plist.push_back(vert_props[1]);
   plist.push_back(vert_props[2]);
@@ -137,7 +137,7 @@ IGL_INLINE bool igl::writePLY(
 
   ply_describe_element(ply, "face", F.rows(),1,&face_props[0]);
   ply_header_complete(ply);
-  int native_binary_type = get_native_binary_type2();
+  int native_binary_type = external::ply::get_native_binary_type2();
   ply_put_element_setup(ply, "vertex");
   for(const auto v : vlist)
   {


### PR DESCRIPTION
I just cherry-picked a fix from upstream's libigl to avoid duplicated definitions of `ply_read` and related functions (conflict between geogram and libigl). Ran into this when building the latest TetWild on debug on Windows.